### PR TITLE
Docker volumes and use db migrations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "gropius-backend"]
 	path = gropius-backend
 	url = ../../ccims/gropius-backend
+[submodule "gropius-frontend"]
+	path = gropius-frontend
+	url = ../../ccims/gropius-frontend

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -7,11 +7,11 @@ services:
       - 7474:7474
       - 7687:7687
     volumes:
-      - /conf
-      - /data
-      - /import
-      - /logs
-      - /plugins
+      - neo4j-conf:/conf
+      - neo4j-data:/data
+      - neo4j-import:/import
+      - neo4j-logs:/logs
+      - neo4j-plugins:/plugins
     environment:
       - NEO4J_server_memory_pagecache_size=1G
       - NEO4J_server_memory_heap_initial__size=1G
@@ -83,6 +83,9 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: root
     ports:
       - 27017:27017
+    volumes:
+      - mongo-data:/data/db
+      - mongo-config:/data/configdb
   mongo-express:
     image: mongo-express:latest
     profiles:
@@ -119,3 +122,11 @@ services:
       - SPRING_DATA_MONGODB_PASSWORD=root
       - GROPIUS_SYNC_LOGIN_SERVICE_BASE=http://dev-login-service:3000/
       - GROPIUS_SYNC_API_SECRET=TODO_loginSecret
+volumes:
+  neo4j-conf:
+  neo4j-data:
+  neo4j-import:
+  neo4j-logs:
+  neo4j-plugins:
+  mongo-data:
+  mongo-config:

--- a/docker-compose-testing.yaml
+++ b/docker-compose-testing.yaml
@@ -67,6 +67,7 @@ services:
     ports:
       - 3000:3000
     environment:
+      - NODE_ENV=testing
       - GROPIUS_LOGIN_SPECIFIC_JWT_SECRET=TodoLoginSpecificLongEnoughAndSecureJwtSecretWithAtLeast256Bit
       - GROPIUS_INTERNAL_BACKEND_ENDPOINT=http://api-internal:8080/graphql
       - GROPIUS_INTERNAL_BACKEND_TOKEN=TodoInternalApiToken
@@ -75,6 +76,14 @@ services:
       - GROPIUS_LOGIN_DATABASE_HOST=postgres
       - GROPIUS_LOGIN_DATABASE_PASSWORD=postgres
       - GROPIUS_LOGIN_SYNC_API_SECRET=TODO_loginSecret
+      - GROPIUS_DEFAULT_STRATEGY_INSTANCE_TYPE=userpass
+      - GROPIUS_DEFAULT_STRATEGY_INSTANCE_CONFIG={}
+      - GROPIUS_DEFAULT_STRATEGY_INSTANCE_NAME=userpass-local
+      - GROPIUS_DEFAULT_USER_USERNAME=TODO_adminUser
+      - GROPIUS_DEFAULT_USER_DISPLAYNAME=System-Admin
+      - 'GROPIUS_DEFAULT_USER_POST_DATA={"password": "TODO_adminPassword"}'
+      - GROPIUS_DEFAULT_USER_STRATEGY_INSTANCE_NAME=userpass-local
+      - GROPIUS_DEFAULT_AUTH_CLIENT_NAME=initial-client
   mongo:
     image: mongo
     restart: unless-stopped

--- a/docker-compose-testing.yaml
+++ b/docker-compose-testing.yaml
@@ -58,7 +58,7 @@ services:
     build:
       context: ./gropius-backend/login-service
       dockerfile: ../../production-container/Dockerfile-nestjs
-    command: /bin/sh -c "npx typeorm migration:run -d dist/migrationDataSource.config.js && node dist/main.js"
+    command: /bin/sh -c "npx typeorm migration:run -d dist/migrationDataSource.config.js && sleep 10 && node dist/main.js"
     depends_on:
       - api-internal
       - postgres

--- a/docker-compose-testing.yaml
+++ b/docker-compose-testing.yaml
@@ -66,7 +66,7 @@ services:
       - 3000:3000
     environment:
       - GROPIUS_LOGIN_SPECIFIC_JWT_SECRET=TodoLoginSpecificLongEnoughAndSecureJwtSecretWithAtLeast256Bit
-      - GROPIUS_INTERNAL_BACKEND_ENDPOINT=http://api-internal:8080
+      - GROPIUS_INTERNAL_BACKEND_ENDPOINT=http://api-internal:8080/graphql
       - GROPIUS_INTERNAL_BACKEND_TOKEN=TodoInternalApiToken
       - GROPIUS_INTERNAL_BACKEND_JWT_SECRET=TodoLongEnoughAndSecureJwtSecretWithAtLeast256Bit
       - GROPIUS_ACCESS_TOKEN_EXPIRATION_TIME_MS=600000

--- a/docker-compose-testing.yaml
+++ b/docker-compose-testing.yaml
@@ -83,6 +83,9 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: root
     ports:
       - 27017:27017
+    volumes:
+      - mongo-data:/data/db
+      - mongo-config:/data/configdb
   github:
     build:
       context: ./gropius-backend
@@ -103,3 +106,13 @@ services:
       - SPRING_DATA_MONGODB_PASSWORD=root
       - GROPIUS_SYNC_LOGIN_SERVICE_BASE=http://login-service:3000/
       - GROPIUS_SYNC_API_SECRET=TODO_loginSecret
+
+volumes:
+  neo4j-conf:
+  neo4j-data:
+  neo4j-import:
+  neo4j-logs:
+  neo4j-plugins:
+  postgres-data:
+  mongo-data:
+  mongo-config:

--- a/docker-compose-testing.yaml
+++ b/docker-compose-testing.yaml
@@ -96,6 +96,16 @@ services:
       - 'GROPIUS_DEFAULT_USER_POST_DATA={"password": "TODO_adminPassword"}'
       - GROPIUS_DEFAULT_USER_STRATEGY_INSTANCE_NAME=userpass-local
       - GROPIUS_DEFAULT_AUTH_CLIENT_NAME=initial-client
+  frontend:
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: production-container/Dockerfile-vue
+    ports:
+      - "4200:80"
+    depends_on:
+      - api-public
+      - login-service
   mongo:
     image: mongo
     restart: unless-stopped

--- a/docker-compose-testing.yaml
+++ b/docker-compose-testing.yaml
@@ -58,6 +58,7 @@ services:
     build:
       context: ./gropius-backend/login-service
       dockerfile: ../../production-container/Dockerfile-nestjs
+    command: npx typeorm migration:run -d dist/migrationDataSource.config.js && node dist/main.js
     depends_on:
       - api-internal
       - postgres

--- a/docker-compose-testing.yaml
+++ b/docker-compose-testing.yaml
@@ -58,7 +58,7 @@ services:
     build:
       context: ./gropius-backend/login-service
       dockerfile: ../../production-container/Dockerfile-nestjs
-    command: npx typeorm migration:run -d dist/migrationDataSource.config.js && node dist/main.js
+    command: /bin/sh -c "npx typeorm migration:run -d dist/migrationDataSource.config.js && node dist/main.js"
     depends_on:
       - api-internal
       - postgres

--- a/docker-compose-testing.yaml
+++ b/docker-compose-testing.yaml
@@ -96,11 +96,14 @@ services:
       - 'GROPIUS_DEFAULT_USER_POST_DATA={"password": "TODO_adminPassword"}'
       - GROPIUS_DEFAULT_USER_STRATEGY_INSTANCE_NAME=userpass-local
       - GROPIUS_DEFAULT_AUTH_CLIENT_NAME=initial-client
+      - GROPIUS_DEFAULT_AUTH_CLIENT_ID=8ee1287d-71ff-4c85-becd-cba829f390a0
   frontend:
     restart: unless-stopped
     build:
       context: .
       dockerfile: production-container/Dockerfile-vue
+      args:
+        - VITE_LOGIN_OAUTH_CLIENT_ID=8ee1287d-71ff-4c85-becd-cba829f390a0
     ports:
       - "4200:80"
     depends_on:

--- a/docker-compose-testing.yaml
+++ b/docker-compose-testing.yaml
@@ -7,11 +7,11 @@ services:
       - 7474:7474
       - 7687:7687
     volumes:
-      - /conf
-      - /data
-      - /import
-      - /logs
-      - /plugins
+      - neo4j-conf:/conf
+      - neo4j-data:/data
+      - neo4j-import:/import
+      - neo4j-logs:/logs
+      - neo4j-plugins:/plugins
     environment:
       - NEO4J_server_memory_pagecache_size=1G
       - NEO4J_server_memory_heap_initial__size=1G
@@ -50,6 +50,8 @@ services:
     restart: unless-stopped
     ports:
       - 5432:5432
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,11 @@ services:
     image: neo4j:5.3.0-community
     restart: unless-stopped
     volumes:
-      - /conf
-      - /data
-      - /import
-      - /logs
-      - /plugins
+      - neo4j-conf:/conf
+      - neo4j-data:/data
+      - neo4j-import:/import
+      - neo4j-logs:/logs
+      - neo4j-plugins:/plugins
     environment:
       - NEO4J_server_memory_pagecache_size=1G
       - NEO4J_server_memory_heap_initial__size=1G
@@ -47,6 +47,8 @@ services:
   postgres:
     image: postgres:14
     restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=TodoPostgresPassword
@@ -73,6 +75,9 @@ services:
   mongo:
     image: mongo
     restart: unless-stopped
+    volumes:
+      - mongo-data:/data/db
+      - mongo-config:/data/configdb
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: TODO_mongo_password
@@ -96,3 +101,13 @@ services:
       - SPRING_DATA_MONGODB_PASSWORD=TODO_mongo_password
       - GROPIUS_SYNC_LOGIN_SERVICE_BASE=http://login-service:3000/
       - GROPIUS_SYNC_API_SECRET=TODO_loginSecret
+
+volumes:
+  neo4j-conf:
+  neo4j-data:
+  neo4j-import:
+  neo4j-logs:
+  neo4j-plugins:
+  postgres-data:
+  mongo-data:
+  mongo-config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
     build:
       context: ./gropius-backend/login-service
       dockerfile: ../../production-container/Dockerfile-nestjs
+    command: /bin/sh -c "npx typeorm migration:run -d dist/migrationDataSource.config.js && sleep 10 && node dist/main.js"
     depends_on:
       - api-internal
       - postgres

--- a/production-container/Dockerfile-nestjs
+++ b/production-container/Dockerfile-nestjs
@@ -13,4 +13,5 @@ WORKDIR /home/node
 COPY --from=0 /home/node/package*.json ./
 COPY --from=0 /home/node/node_modules ./node_modules/
 COPY --from=0 /home/node/dist ./dist/
+COPY --from=0 /home/node/static ./static/
 CMD ["node", "dist/main.js"]

--- a/production-container/Dockerfile-vue
+++ b/production-container/Dockerfile-vue
@@ -1,0 +1,23 @@
+# Use the official Node.js image to build the Vue frontend
+FROM node:21 AS builder
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the frontend source code into the container
+COPY gropius-frontend /app
+
+# Install dependencies and build the frontend
+RUN npm install
+RUN cd packages/graph-editor && npm run build
+RUN npm run build
+
+# Create a production-ready image with Nginx
+FROM nginx:latest
+
+# Copy the built frontend files from the builder stage to the Nginx server
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Copy a custom Nginx configuration that handles Vue SPA routing
+RUN rm /etc/nginx/conf.d/default.conf
+COPY production-container/nginx.conf /etc/nginx/conf.d

--- a/production-container/Dockerfile-vue
+++ b/production-container/Dockerfile-vue
@@ -7,6 +7,9 @@ WORKDIR /app
 # Copy the frontend source code into the container
 COPY gropius-frontend /app
 
+ARG VITE_LOGIN_OAUTH_CLIENT_ID
+ENV VITE_LOGIN_OAUTH_CLIENT_ID=$VITE_LOGIN_OAUTH_CLIENT_ID
+
 # Install dependencies and build the frontend
 RUN npm install
 RUN cd packages/graph-editor && npm run build

--- a/production-container/nginx.conf
+++ b/production-container/nginx.conf
@@ -1,0 +1,40 @@
+server {
+    listen 80;
+
+    # Root directory
+    location / {
+        root   /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Proxy /api/graphql
+    location /api/graphql {
+        proxy_pass http://api-public:8080/graphql;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+    }
+
+    # Proxy /api/login
+    location /api/login {
+        proxy_pass http://login-service:3000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+
+        # Remove /api/login from the forwarded path
+        rewrite ^/api/login/(.*) /$1 break;
+    }
+}


### PR DESCRIPTION
- Updates the docker compose setup to have named volumes (so they don't get deleted on `docker compose down` (without --volumes))
- Ensures the database of the login service is up to date by running the migrations on startup of the container

Depends on https://github.com/ccims/gropius-backend/pull/51